### PR TITLE
chore: add go-ipld-prime compat test case for bytes

### DIFF
--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -23,6 +23,14 @@ describe('basic dag-json', () => {
     same(bytes.isBinary(decode(byts).byts), true)
   })
 
+  test('encode decode 2', () => {
+    const obj = { plain: 'olde string', bytes: new TextEncoder().encode('deadbeef') }
+    const expected = '{"plain":"olde string","bytes": {"/":{"bytes":"mZGVhZGJlZWY"}}}'
+    const byts = encode(obj)
+    same(JSON.parse(bytes.toString(recode(byts))), JSON.parse(expected))
+    same(bytes.toString(recode(byts)), expected)
+  })
+
   describe('reserved space', () => {
     test('allow alternative types', () => {
       //  wrong types


### PR DESCRIPTION
Ref: https://github.com/ipld/specs/pull/356
Ref: https://github.com/ipld/go-ipld-prime/pull/168

PR for discussion atm

failing right now, it's not sorted the same, ipld-prime doesn't do sorting