### PR TITLE
fix!: decode large non-safe numbers with no decimal as BigInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,6 @@ export const encode = (node) => cborgJson.encode(node, encodeOptions)
  */
 export const decode = (data) => {
   // the tokenizer is stateful so we need a single instance of it
-  const options = Object.assign(decodeOptions, { tokenizer: new DagJsonTokenizer(data) })
+  const options = Object.assign(decodeOptions, { tokenizer: new DagJsonTokenizer(data, decodeOptions) })
   return cborgJson.decode(data, options)
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/ipld/js-dag-json",
   "dependencies": {
-    "cborg": "^1.3.1",
+    "cborg": "^1.4.0",
     "multiformats": "^9.0.0"
   },
   "devDependencies": {

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -80,6 +80,32 @@ describe('basic dag-json', () => {
     same('{"a":1,"b":2,"bb":2.2,"c":3,"c_":3.3}', s2)
   })
 
+  test('bigints', () => {
+    const verify = (inp) => {
+      assert.strictEqual(decode(new TextEncoder().encode(String(inp))), inp)
+    }
+
+    // plain Number objects
+    verify(0)
+    verify(1)
+    verify(-1)
+    verify(Math.pow(2, 50))
+    verify(-Math.pow(2, 50))
+    verify(Number.MAX_SAFE_INTEGER)
+    verify(-Number.MAX_SAFE_INTEGER)
+    // should round-trip as BigInts
+    verify(BigInt('9007199254740992')) // Number.MAX_SAFE_INTEGER+1
+    verify(BigInt('9007199254740993'))
+    verify(BigInt('11959030306112471731'))
+    verify(BigInt('18446744073709551615')) // max uint64
+    verify(BigInt('9223372036854775807')) // max int64
+    verify(BigInt('-9007199254740992'))
+    verify(BigInt('-9007199254740993'))
+    verify(BigInt('-9223372036854776000')) // min int64
+    verify(BigInt('-11959030306112471732'))
+    verify(BigInt('-18446744073709551616')) // min -uint64
+  })
+
   test('error on circular references', () => {
     const circularObj = {}
     circularObj.a = circularObj


### PR DESCRIPTION
Heads up @achingbrain, this is going to make dag-json do the same thing that dag-cbor does, returns `BigInt` when you're outside of safe integer range. We're currently in a lossy situation with those numbers, but with this change we get to safely pull the integer out as it is in the encoded JSON.

But, it's a breaking change because previously it's all just `Number`.

---

BREAKING CHANGE

Because previously, all numbers just get decoded as `Number`, after this
change any number in the JSON that doesn't have a decimal place and is
outside of the JavaScript safe integer range will be provided as a
`BigInt`.