### PR TITLE
fix: bring back asCID check for backward compat with multiformats@<10

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import * as cborgJson from 'cborg/json'
  * @returns {Token[]|null}
  */
 function cidEncoder (obj) {
-  if (obj['/'] == null || obj['/'] !== obj.bytes) {
+  if (obj.asCID !== obj && obj['/'] !== obj.bytes) {
     return null // any other kind of object
   }
   const cid = CID.asCID(obj)


### PR DESCRIPTION
Ref: https://github.com/ipld/codec-fixtures/pull/72

Currently failing tests when the new dag-json goes in to codec-fixtures without upgrading the rest—so data coming from another pre-multiformats@9 codec into multiformats@10 dag-json doesn't result in the expected output and I believe this is to blame.

Same code for this as dag-cbor.