### PR TITLE
fix: add entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ipld/dag-json",
   "version": "10.0.0",
+  "main": "./dist/index.min.js",
   "description": "JS implementation of DAG-JSON",
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "Apache-2.0 OR MIT",


### PR DESCRIPTION
This field is required to recognise library entry point in metro bundler

this change fixes this error
<img width="529" alt="image" src="https://user-images.githubusercontent.com/52166642/215042542-8b8d5871-d957-42f1-b95d-6e25a1f90fef.png">
