### PR TITLE
fix: error on base64pad

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,15 +17,18 @@ import * as cborgJson from 'cborg/json'
  */
 
 /**
- * cidEncoder will receive all Objects during encode, it needs to filter out
- * anything that's not a CID and return `null` for that so it's encoded as
- * normal. Encoding a CID means replacing it with a `{"/":"<CidString>}`
+ * objectEncoder encodes CIDs and validates bytes. It will receive all Objects
+ * during encode. return `null` to filter out objects that should be encoded
+ * as normal. Encoding a CID means replacing it with a `{"/":"<CidString>}`
  * object as per the DAG-JSON spec.
  *
  * @param {any} obj
  * @returns {Token[]|null}
  */
-function cidEncoder (obj) {
+function objectEncoder (obj) {
+  if (obj['/'] && obj['/'].bytes && obj['/'].bytes[obj['/'].bytes.length - 1] === '=') {
+    throw new Error('bytes value must be base64 encoded without padding')
+  }
   if (obj.asCID !== obj && obj['/'] !== obj.bytes) {
     return null // any other kind of object
   }
@@ -97,7 +100,7 @@ function numberEncoder (num) {
 
 const encodeOptions = {
   typeEncoders: {
-    Object: cidEncoder,
+    Object: objectEncoder,
     Uint8Array: bytesEncoder, // TODO: all the typedarrays
     Buffer: bytesEncoder, // TODO: all the typedarrays
     undefined: undefinedEncoder,

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -187,4 +187,8 @@ describe('basic dag-json', () => {
   test('reject duplicate map keys', () => {
     assert.throws(() => decode(new TextEncoder().encode('{"foo":1,"foo":2,"bar":3}')), /found repeat map key "foo"/)
   })
+
+  test('reject base64pad bytes', () => {
+    assert.throws(() => encode({ '/': { bytes: 'eA==' } }), /bytes value must be base64 encoded without padding/)
+  })
 })


### PR DESCRIPTION
Opening this for discussion. I'm not wise enough to know if this change is a good idea, but base64pad strings as bytes values change the encoded form and are forbidden per the spec.

Notably it will make some exiting IPNI advertisements unencodable. But in principle, the encoder should probably warn the user when they try to encode an illegal bytes string.

> The Base64 encoding is the one described in [RFC 4648, section 4](https://tools.ietf.org/html/rfc4648#section-4) **without padding.**
> – https://ipld.io/specs/codecs/dag-json/spec/#bytes

fixes: https://github.com/ipld/js-dag-json/issues/106

License: MIT