### PR TITLE
feat: TypedArray type conversions (and address other new lint complaints)

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,6 @@
   },
   "devDependencies": {
     "@ipld/garbage": "^6.0.0",
-    "aegir": "^38.1.2"
+    "aegir": "^39.0.7"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 /* eslint max-depth: ["error", 7] */
-import { CID } from 'multiformats'
-import { base64 } from 'multiformats/bases/base64'
 import { Token, Type } from 'cborg'
 import * as cborgJson from 'cborg/json'
+import { CID } from 'multiformats'
+import { base64 } from 'multiformats/bases/base64'
 
 /**
  * @template T
@@ -66,6 +66,27 @@ function bytesEncoder (bytes) {
   ]
 }
 
+/**
+ * taBytesEncoder wraps bytesEncoder() but for the more exotic typed arrays so
+ * that we access the underlying ArrayBuffer data
+ *
+ * @param {Int8Array|Uint16Array|Int16Array|Uint32Array|Int32Array|Float32Array|Float64Array|Uint8ClampedArray|BigInt64Array|BigUint64Array} obj
+ * @returns {Token[]|null}
+ */
+function taBytesEncoder (obj) {
+  return bytesEncoder(new Uint8Array(obj.buffer, obj.byteOffset, obj.byteLength))
+}
+
+/**
+ * abBytesEncoder wraps bytesEncoder() but for plain ArrayBuffers
+ *
+ * @param {ArrayBuffer} ab
+ * @returns {Token[]|null}
+ */
+function abBytesEncoder (ab) {
+  return bytesEncoder(new Uint8Array(ab))
+}
+
 // eslint-disable-next-line jsdoc/require-returns-check
 /**
  * Intercept all `undefined` values from an object walk and reject the entire
@@ -98,8 +119,20 @@ function numberEncoder (num) {
 const encodeOptions = {
   typeEncoders: {
     Object: cidEncoder,
-    Uint8Array: bytesEncoder, // TODO: all the typedarrays
-    Buffer: bytesEncoder, // TODO: all the typedarrays
+    Buffer: bytesEncoder,
+    Uint8Array: bytesEncoder,
+    Int8Array: taBytesEncoder,
+    Uint16Array: taBytesEncoder,
+    Int16Array: taBytesEncoder,
+    Uint32Array: taBytesEncoder,
+    Int32Array: taBytesEncoder,
+    Float32Array: taBytesEncoder,
+    Float64Array: taBytesEncoder,
+    Uint8ClampedArray: taBytesEncoder,
+    BigInt64Array: taBytesEncoder,
+    BigUint64Array: taBytesEncoder,
+    DataView: taBytesEncoder,
+    ArrayBuffer: abBytesEncoder,
     undefined: undefinedEncoder,
     number: numberEncoder
   }


### PR DESCRIPTION
This is https://github.com/ipld/js-dag-json/pull/108 but with linting fixed, one of which is getting rid of TODOs. The big one is that we didn't have typeEncoders for each of the typed array types, I've done that now and also included tests that mirror the ones that work for dag-cbor. It's worth noting here that this behaviour may not be the best - because they all round-trip as `Uint8Array`s you get a loss of information, which may be surprising. It may be better behaviour to just reject them as unsupported, like we do for other exotic types, `RegExp`, `Date`, etc. But, we do it already in dag-cbor, and we do a bit of fiddling with bigints already too so that the round-trip isn't necessarily consistent so it is what it is for now and can perhaps be changed in a future breaking release.