### PR TITLE
feat: support decoding ArrayBuffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "cborg": "^4.0.0",
-    "multiformats": "^13.0.0"
+    "multiformats": "^13.1.0"
   },
   "devDependencies": {
     "@ipld/garbage": "^6.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,28 @@ import { base64 } from 'multiformats/bases/base64'
  */
 /**
  * @template T
+ * @typedef {import('multiformats/codecs/interface').ArrayBufferView<T>} ArrayBufferView
+ */
+/**
+ * @template T
  * @typedef {import('multiformats').ToString<T>} ToString
  */
 /**
  * @typedef {import('cborg/interface').DecodeTokenizer} DecodeTokenizer
  */
+
+/**
+ * @template T
+ * @param {ByteView<T> | ArrayBufferView<T>} buf
+ * @returns {ByteView<T>}
+ */
+function toByteView (buf) {
+  if (buf instanceof ArrayBuffer) {
+    return new Uint8Array(buf, 0, buf.byteLength)
+  }
+
+  return buf
+}
 
 /**
  * cidEncoder will receive all Objects during encode, it needs to filter out
@@ -246,13 +263,14 @@ export const encode = (node) => cborgJson.encode(node, encodeOptions)
 
 /**
  * @template T
- * @param {ByteView<T>} data
+ * @param {ByteView<T> | ArrayBufferView<T>} data
  * @returns {T}
  */
 export const decode = (data) => {
+  const buf = toByteView(data)
   // the tokenizer is stateful so we need a single instance of it
-  const options = Object.assign(decodeOptions, { tokenizer: new DagJsonTokenizer(data, decodeOptions) })
-  return cborgJson.decode(data, options)
+  const options = Object.assign(decodeOptions, { tokenizer: new DagJsonTokenizer(buf, decodeOptions) })
+  return cborgJson.decode(buf, options)
 }
 
 /**

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -30,6 +30,15 @@ describe('basic dag-json', () => {
     same(bytes.toString(recode(byts)), expected)
   })
 
+  it('encode decode with ArrayBuffer', () => {
+    const byts = encode({ hello: 'world' })
+    same(JSON.parse(bytes.toString(recode(byts))), { hello: 'world' })
+    const o = { link, byts: bytes.fromString('asdf'), n: null, o: {} }
+    const byts2 = encode(o)
+    same(decode(byts2), o)
+    same(bytes.isBinary(decode(byts2).byts.buffer), true)
+  })
+
   describe('reserved space', () => {
     it('allow alternative types', () => {
       //  wrong types

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -15,6 +15,9 @@ function useCodecFeature (codec: BlockCodec<297, any>) {
   // use only as a BlockDecoder
   useDecoder(codec)
 
+  // use with ArrayBuffer input type
+  useDecoderWithArrayBuffer(codec)
+
   // use as a full BlockCodec which does both BlockEncoder & BlockDecoder
   useBlockCodec(codec)
 }
@@ -29,6 +32,12 @@ function useEncoder<Codec extends number> (encoder: BlockEncoder<Codec, string>)
 function useDecoder<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
   deepStrictEqual(decoder.code, 297)
   deepStrictEqual(decoder.decode(Uint8Array.from([34, 98, 108, 105, 112, 34 ])), 'blip')
+  console.log('[TS] ✓ { decoder: BlockDecoder }')
+}
+
+function useDecoderWithArrayBuffer<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
+  deepStrictEqual(decoder.code, 297)
+  deepStrictEqual(decoder.decode(Uint8Array.from([34, 98, 108, 105, 112, 34 ]).buffer), 'blip')
   console.log('[TS] ✓ { decoder: BlockDecoder }')
 }
 


### PR DESCRIPTION
Expands supported input types to include `ArrayBuffer`s to make it easiser for users to use modules like `fetch` that don't return `Uint8Array`s.