### PR TITLE
fix!: update multiformats to 14.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   },
   "dependencies": {
     "cborg": "^5.0.0",
-    "multiformats": "^13.1.0"
+    "multiformats": "^14.0.0"
   },
   "devDependencies": {
     "@ipld/garbage": "^6.0.0",


### PR DESCRIPTION
Releasing as a major as nested `Uint8Array` properties of the CID class can cause issues where consuming code hasn't also updated to the latest multiformats like:

```
Error: test-e2e/first-hit.test.ts(123,11): error TS2322: Type 'CID<unknown, 85, 0, 1>' is not assignable to type 'CID<unknown, number, number, Version>'.
  The types of 'multihash.digest' are incompatible between these types.
    Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
```

BREAKING CHANGE: CIDs returned from this module are from  multiformats@14.x.x